### PR TITLE
Fix four runtime bugs found in second review pass

### DIFF
--- a/python_magnetworkflows/commissioning.py
+++ b/python_magnetworkflows/commissioning.py
@@ -106,8 +106,8 @@ def main():
     Currents = []
     step_i = {}
     for mname, values in args.mdata.items():
-        filter = values.get("filter", "")
-        global_df[filter[:-1]] = {
+        mfilter = values.get("filter", "")
+        global_df[mfilter[:-1]] = {
             "PowerM": pd.DataFrame(),
             "PowerH": pd.DataFrame(),
             "Flux": pd.DataFrame(),
@@ -118,16 +118,16 @@ def main():
             "Uw": pd.DataFrame(),
         }
         if "Z" in args.cooling:
-            global_df[filter[:-1]]["FluxZ"] = pd.DataFrame()
+            global_df[mfilter[:-1]]["FluxZ"] = pd.DataFrame()
         if "H" in args.cooling:
-            global_df[filter[:-1]]["cf"] = pd.DataFrame()
+            global_df[mfilter[:-1]]["cf"] = pd.DataFrame()
         if "thmagel" in args.cfgfile:
-            global_df[filter[:-1]]["statsDispl"] = pd.DataFrame()
-            global_df[filter[:-1]]["statsStress"] = pd.DataFrame()
-            global_df[filter[:-1]]["statsVonMises"] = pd.DataFrame()
-            global_df[filter[:-1]]["statsDisplH"] = pd.DataFrame()
-            global_df[filter[:-1]]["statsStressH"] = pd.DataFrame()
-            global_df[filter[:-1]]["statsVonMisesH"] = pd.DataFrame()
+            global_df[mfilter[:-1]]["statsDispl"] = pd.DataFrame()
+            global_df[mfilter[:-1]]["statsStress"] = pd.DataFrame()
+            global_df[mfilter[:-1]]["statsVonMises"] = pd.DataFrame()
+            global_df[mfilter[:-1]]["statsDisplH"] = pd.DataFrame()
+            global_df[mfilter[:-1]]["statsStressH"] = pd.DataFrame()
+            global_df[mfilter[:-1]]["statsVonMisesH"] = pd.DataFrame()
 
         if "steplist" in values:
             step_i[mname] = 0
@@ -213,19 +213,19 @@ def main():
 
         nstep += 1
         for i, (mname, values) in enumerate(args.mdata.items()):
-            filter = values.get("filter", "")
+            mfilter = values.get("filter", "")
             if "steplist" in values:
                 step_i[mname] += 1
                 if len(values["steplist"]) == step_i[mname]:
                     Commissioning = False
                 else:
-                    targets[f"{filter}I"]["objectif"] = values["steplist"][
+                    targets[f"{mfilter}I"]["objectif"] = values["steplist"][
                         step_i[mname]
                     ]
-                Currents[i] = targets[f"{filter}I"]["objectif"]
+                Currents[i] = targets[f"{mfilter}I"]["objectif"]
             else:
-                targets[f"{filter}I"]["objectif"] -= values["step"]
-                Currents[i] = targets[f"{filter}I"]["objectif"]
+                targets[f"{mfilter}I"]["objectif"] -= values["step"]
+                Currents[i] = targets[f"{mfilter}I"]["objectif"]
                 if Currents[i] <= 0 or nstep >= values["stepmax"]:
                     Commissioning = False
 

--- a/python_magnetworkflows/cooling.py
+++ b/python_magnetworkflows/cooling.py
@@ -199,7 +199,7 @@ def Filonenko(Re: float, Dh: float, f: float, rugosity: float) -> float:
 
 def Colebrook(Re: float, Dh: float, f: float, rugosity: float) -> float:
     val = 1 / sqrt(f)
-    isOK = False
+    isOk = False
     it = 0
     max_err = 1.0e-3
     while it < 10:
@@ -353,7 +353,7 @@ def hcorrelation(
 
     (alpha, n, m) = params
     Steam = steam(Tw, Pw)
-    nU = Uw(
+    nU, _ = Uw(
         Steam,
         dPw,
         Dh,

--- a/python_magnetworkflows/error.py
+++ b/python_magnetworkflows/error.py
@@ -710,9 +710,11 @@ def compute_error(
                 if FluxZ is not None:
                     csvfile = resolve_cfgdir_path(TwH[i]["filename"], basedir)
                     print(f"{target}: channel[{i}]: write csv {csvfile} for TwH[{i}], Tw_data columns={Tw_data.columns.values.tolist()}", flush=True)
-                    # Drop hw column if it exists before saving
+                    # Drop hw column when not gradHZH (gradHZH re-uses hw for next iter)
                     if args.cooling == "gradHZ":
                         Tw_data_save = Tw_data.drop(columns=["hw"], errors="ignore")
+                    else:
+                        Tw_data_save = Tw_data
                     Tw_data_save.to_csv(csvfile, index=False)
                 Steam = steam(tmp_Twh + dTwi[i] / 2.0, Pressure)
                 VolMass[i] = Steam.rho


### PR DESCRIPTION
1. cooling.py Colebrook: rename `isOK` -> `isOk` to match the flag written inside the loop; previously a NameError would be raised whenever the fixed-point iteration failed to converge within 10 steps.

2. cooling.py hcorrelation: unpack the (U, f) tuple returned by Uw() with `nU, _ = Uw(...)` instead of storing the whole tuple in `nU`; passing a tuple to Reynolds() as the velocity argument caused a TypeError for all Dittus / Colburn / Silverberg correlations.

3. error.py: add `else: Tw_data_save = Tw_data` so that the gradHZH cooling path also defines Tw_data_save before calling .to_csv(); previously a NameError was raised for any gradHZH run.

4. commissioning.py: rename loop variable `filter` -> `mfilter` in both loops that iterate over args.mdata; mirrors the fix already applied to cli.py in commit a98eec3 and avoids shadowing the Python built-in.

https://claude.ai/code/session_0168WE8nZsuZPfnhpBse2Fyo