### PR TITLE
Add test suite with feelpp-conditional test support

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,161 @@
+# Testing python_magnetworkflows
+
+## Overview
+
+The test suite is split into two tiers:
+
+| Tier | Files | When they run | Requirements |
+|------|-------|---------------|--------------|
+| Pure Python | `test_params.py`, `test_args.py`, `test_real_methods.py` | Always | Standard dev dependencies only |
+| feelpp-gated | `test_solver.py`, `test_integration.py` | Only when feelpp is installed | feelpp system package + simulation data |
+
+Tests that require feelpp are skipped entirely at collection time (via
+`pytest.importorskip`) when the library is absent — no error, no false
+failures.
+
+---
+
+## Quick start (no feelpp required)
+
+```bash
+# Install the package in editable mode with dev dependencies
+pip install -e ".[dev]"
+
+# Run the pure-Python tests
+pytest -m "not feelpp" -v
+
+# Or just run everything (feelpp tests auto-skip)
+pytest -v
+```
+
+Expected output when feelpp is not installed:
+- `test_params.py`, `test_args.py`, `test_real_methods.py`: all pass
+- `test_solver.py`, `test_integration.py`: entire files shown as **skipped**
+
+---
+
+## Setting up feelpp
+
+feelpp is distributed as Debian packages from the LNCMI apt repository. It
+cannot be installed via `pip`.
+
+```bash
+# Add the feelpp apt repository (Ubuntu Noble / Debian 13)
+curl -fsSL http://apt.feelpp.org/ubuntu/noble/feelpp.gpg | sudo tee /etc/apt/trusted.gpg.d/feelpp.gpg
+echo "deb http://apt.feelpp.org/ubuntu/noble noble latest" | sudo tee /etc/apt/sources.list.d/feelpp.list
+sudo apt-get update
+
+# Install required packages
+sudo apt-get install -y \
+  python3-feelpp \
+  python3-feelpp-toolboxes \
+  feelpp-toolboxes-coefficientformpdes \
+  feelpp-toolboxes-data \
+  feelpp-data
+```
+
+See `.devcontainer/Dockerfile` for the complete list of packages used in
+the development container, and `singularity.def` for the HPC container setup.
+
+### Virtual environment with system packages
+
+Because feelpp is a system package (not pip-installable), you **must**
+create the virtual environment with `--system-site-packages`:
+
+```bash
+python3 -m venv .venv --system-site-packages
+source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+Without `--system-site-packages`, `import feelpp` will fail even when the
+Debian packages are installed.
+
+---
+
+## Pytest markers
+
+| Marker | Meaning | How to deselect |
+|--------|---------|-----------------|
+| `feelpp` | Requires the feelpp Debian system package | `-m "not feelpp"` |
+| `slow` | Requires real simulation data; may run for minutes to hours | `-m "not slow"` |
+
+### Useful invocations
+
+```bash
+# Pure Python only (fastest)
+pytest -m "not feelpp" -v
+
+# feelpp import/unit tests only (fast, no simulation data needed)
+pytest -m "feelpp and not slow" -v
+
+# All feelpp tests including integration (requires MAGNETWORKFLOWS_TEST_DATA)
+pytest -m "feelpp" -v
+
+# Full suite
+pytest -v
+```
+
+---
+
+## Integration tests (simulation data required)
+
+Integration tests in `test_integration.py` actually launch the Feel++
+coupled solver. Each test can take several minutes on a typical workstation.
+Full commissioning runs (multiple current steps) may take hours.
+
+### Providing test data
+
+Set the `MAGNETWORKFLOWS_TEST_DATA` environment variable to a directory
+containing simulation inputs. The structure should mirror the example shell
+scripts in `examples/`:
+
+```
+$MAGNETWORKFLOWS_TEST_DATA/
+├── HLTEST/
+│   ├── HLtest-flow_params.json
+│   └── mean/
+│       ├── HLtest-cfpdes-thmag_hcurl-nonlinear-Axi-sim.cfg
+│       └── <mesh + json model files>
+└── M9Bitters_18MW/
+    ├── M9Bitters_18MW-flow_params.json
+    └── gradHZ/
+        ├── M9Bitters_18MW-cfpdes-thmag_hcurl-nonlinear-Axi-sim.cfg
+        └── <mesh + json model files>
+```
+
+If `MAGNETWORKFLOWS_TEST_DATA` is not set (or the path does not exist),
+all integration tests are automatically skipped with a descriptive message.
+
+### Running integration tests
+
+```bash
+export MAGNETWORKFLOWS_TEST_DATA=~/jeremie-simus
+pytest -m "feelpp and slow" -v --timeout=3600
+```
+
+### Example shell scripts as manual tests
+
+The scripts in `examples/` are manual smoke tests that serve as the
+reference for what a passing integration run looks like:
+
+| Script | Magnet type | Notes |
+|--------|-------------|-------|
+| `examples/HLTEST.sh` | Helix | Single config, `--no-update-cooling` |
+| `examples/M9Bitters.sh` | Bitter | Commissioning ramp (multi-step) |
+| `examples/Tore_thmagel.sh` | Bitter (thmagel) | Single config |
+| `examples/Tore_thmagel_hcurl.sh` | Bitter (thmagel_hcurl) | Single config |
+| `examples/Toretest.sh` | Bitter (thmag_hcurl) | Single config |
+
+These scripts expect their working directories to exist under `~/jeremie-simus/`.
+
+---
+
+## CI recommendations
+
+- Run `pytest -m "not feelpp"` in every CI job (no special environment needed).
+- Gate `pytest -m "feelpp and not slow"` on a separate job with feelpp
+  installed (e.g., using the devcontainer image).
+- Gate `pytest -m "feelpp and slow"` on a dedicated job with access to
+  simulation data; this job can have a long timeout and run on schedule
+  rather than on every commit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,10 @@ ignore_missing_imports = true   # feel++ stubs are not available
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "feelpp: mark test as requiring the feelpp Debian system package (deselect with '-m not feelpp')",
+    "slow: mark test as requiring real simulation data and significant runtime (deselect with '-m not slow')",
+]
 filterwarnings = [
     "error",
     "ignore::UserWarning",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,58 @@
+"""
+Shared pytest configuration and fixtures for python_magnetworkflows tests.
+
+Two custom markers are registered here (and in pyproject.toml):
+- ``feelpp``: test requires the feelpp Debian system package
+- ``slow``:   test requires real simulation data and significant runtime
+
+Skip logic for feelpp-dependent test *modules* is handled by
+``pytest.importorskip("feelpp.core")`` at the top of each affected file —
+this skips the entire module at collection time rather than per-test,
+which is the cleanest pattern when the module itself cannot be imported
+without feelpp.
+"""
+
+import os
+
+import pytest
+
+DATA_DIR_ENV = "MAGNETWORKFLOWS_TEST_DATA"
+
+
+def pytest_configure(config):
+    """Register custom markers so pytest does not warn about unknown marks."""
+    config.addinivalue_line(
+        "markers",
+        "feelpp: mark test as requiring the feelpp Debian system package "
+        "(deselect with '-m not feelpp')",
+    )
+    config.addinivalue_line(
+        "markers",
+        "slow: mark test as requiring real simulation data and significant runtime "
+        "(deselect with '-m not slow')",
+    )
+
+
+@pytest.fixture(scope="session")
+def feelpp_test_data():
+    """Return the path to a directory containing test simulation inputs.
+
+    Set the environment variable ``MAGNETWORKFLOWS_TEST_DATA`` to a directory
+    that mirrors the structure used by the example shell scripts in
+    ``examples/``, e.g.::
+
+        HLTEST/mean/HLtest-cfpdes-thmag_hcurl-nonlinear-Axi-sim.cfg
+        HLTEST/HLtest-flow_params.json
+        M9Bitters_18MW/gradHZ/M9Bitters_18MW-cfpdes-thmag_hcurl-nonlinear-Axi-sim.cfg
+        M9Bitters_18MW/M9Bitters_18MW-flow_params.json
+
+    If the variable is unset or the directory does not exist, integration tests
+    are automatically skipped.
+    """
+    data_dir = os.environ.get(DATA_DIR_ENV)
+    if not data_dir or not os.path.isdir(data_dir):
+        pytest.skip(
+            f"Set {DATA_DIR_ENV} to a directory with simulation inputs "
+            "to run integration tests (see examples/*.sh for the expected structure)."
+        )
+    return data_dir

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -1,0 +1,160 @@
+"""
+Tests for python_magnetworkflows.args
+
+All tests in this file are pure Python — no feelpp dependency.
+"""
+
+import argparse
+import json
+
+import pytest
+
+from python_magnetworkflows.args import options
+
+
+@pytest.fixture()
+def parser():
+    return options("Test description", "Test epilog")
+
+
+# ---------------------------------------------------------------------------
+# Basic structure
+# ---------------------------------------------------------------------------
+
+
+def test_options_returns_argument_parser(parser):
+    assert isinstance(parser, argparse.ArgumentParser)
+
+
+def test_cfgfile_positional_required(parser):
+    with pytest.raises(SystemExit):
+        parser.parse_args([])
+
+
+def test_cfgfile_is_set(parser):
+    args = parser.parse_args(["myfile.cfg"])
+    assert args.cfgfile == "myfile.cfg"
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+
+def test_default_cooling(parser):
+    args = parser.parse_args(["myfile.cfg"])
+    assert args.cooling == "mean"
+
+
+def test_default_heatcorrelation(parser):
+    args = parser.parse_args(["myfile.cfg"])
+    assert args.heatcorrelation == "Montgomery"
+
+
+def test_default_friction(parser):
+    args = parser.parse_args(["myfile.cfg"])
+    assert args.friction == "Constant"
+
+
+def test_default_eps(parser):
+    args = parser.parse_args(["myfile.cfg"])
+    assert args.eps == pytest.approx(1.0e-3)
+
+
+def test_default_heatTol(parser):
+    args = parser.parse_args(["myfile.cfg"])
+    assert args.heatTol == pytest.approx(1.0e-2)
+
+
+def test_default_itermax(parser):
+    args = parser.parse_args(["myfile.cfg"])
+    assert args.itermax == 10
+
+
+def test_default_update_cooling_true(parser):
+    args = parser.parse_args(["myfile.cfg"])
+    assert args.update_cooling is True
+
+
+def test_default_reloadcfg_true(parser):
+    args = parser.parse_args(["myfile.cfg"])
+    assert args.reloadcfg is True
+
+
+def test_default_debug_false(parser):
+    args = parser.parse_args(["myfile.cfg"])
+    assert args.debug is False
+
+
+def test_default_verbose_false(parser):
+    args = parser.parse_args(["myfile.cfg"])
+    assert args.verbose is False
+
+
+def test_default_wd(parser):
+    args = parser.parse_args(["myfile.cfg"])
+    assert args.wd == "."
+
+
+# ---------------------------------------------------------------------------
+# Flag overrides
+# ---------------------------------------------------------------------------
+
+
+def test_no_update_cooling_flag(parser):
+    args = parser.parse_args(["myfile.cfg", "--no-update-cooling"])
+    assert args.update_cooling is False
+
+
+def test_no_reloadcfg_flag(parser):
+    args = parser.parse_args(["myfile.cfg", "--no-reloadcfg"])
+    assert args.reloadcfg is False
+
+
+def test_debug_flag(parser):
+    args = parser.parse_args(["myfile.cfg", "--debug"])
+    assert args.debug is True
+
+
+def test_verbose_flag(parser):
+    args = parser.parse_args(["myfile.cfg", "--verbose"])
+    assert args.verbose is True
+
+
+def test_wd_override(parser):
+    args = parser.parse_args(["myfile.cfg", "--wd", "/tmp/work"])
+    assert args.wd == "/tmp/work"
+
+
+# ---------------------------------------------------------------------------
+# Type coercion and validation
+# ---------------------------------------------------------------------------
+
+
+def test_eps_type_is_float(parser):
+    args = parser.parse_args(["myfile.cfg", "--eps", "1e-5"])
+    assert isinstance(args.eps, float)
+    assert args.eps == pytest.approx(1e-5)
+
+
+def test_itermax_type_is_int(parser):
+    args = parser.parse_args(["myfile.cfg", "--itermax", "20"])
+    assert isinstance(args.itermax, int)
+    assert args.itermax == 20
+
+
+def test_invalid_cooling_choice_raises(parser):
+    with pytest.raises(SystemExit):
+        parser.parse_args(["myfile.cfg", "--cooling", "invalid"])
+
+
+def test_valid_cooling_choices(parser):
+    for cooling in ["mean", "grad", "meanH", "gradH", "gradHZ", "gradHZH"]:
+        args = parser.parse_args(["myfile.cfg", "--cooling", cooling])
+        assert args.cooling == cooling
+
+
+def test_mdata_parses_json(parser):
+    mdata_str = '{"test": {"value": 31000, "type": "helix"}}'
+    args = parser.parse_args(["myfile.cfg", "--mdata", mdata_str])
+    assert args.mdata == json.loads(mdata_str)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,129 @@
+"""
+Integration tests for python_magnetworkflows — require feelpp AND real simulation data.
+
+These tests mirror the example shell scripts in ``examples/`` and launch
+actual Feel++ simulations. They are marked both ``feelpp`` and ``slow``
+because they can take minutes to hours depending on the mesh and physics.
+
+To run these tests:
+1. Install feelpp as a Debian system package (see docs/testing.md)
+2. Set the MAGNETWORKFLOWS_TEST_DATA environment variable to a directory
+   containing simulation inputs (see the fixture in conftest.py):
+
+       export MAGNETWORKFLOWS_TEST_DATA=~/jeremie-simus
+       pytest -m "feelpp and slow" -v
+
+The ``feelpp_test_data`` fixture (defined in conftest.py) will skip the
+entire test session if the env var is missing or the path does not exist.
+"""
+
+import json
+import os
+
+import pytest
+
+pytest.importorskip("feelpp.core")
+
+pytestmark = [pytest.mark.feelpp, pytest.mark.slow]
+
+from python_magnetworkflows.args import options  # noqa: E402
+from python_magnetworkflows.oneconfig import oneconfig  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _cfg(data_dir: str, *parts: str) -> str:
+    """Build an absolute path and skip if the file does not exist."""
+    path = os.path.join(data_dir, *parts)
+    if not os.path.exists(path):
+        pytest.skip(f"Test data not found: {path}")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# HLTEST — helix magnet, single config (mirrors examples/HLTEST.sh)
+# ---------------------------------------------------------------------------
+
+
+def test_hltest_helix_oneconfig(feelpp_test_data, tmp_path):
+    """
+    Smoke integration test mirroring examples/HLTEST.sh.
+
+    Runs one coupled EM-thermal-hydraulic iteration with ``--no-update-cooling``
+    (fastest path) and verifies that ``oneconfig`` completes without raising
+    and returns a non-empty result table.
+    """
+    cfg = _cfg(feelpp_test_data, "HLTEST", "mean", "HLtest-cfpdes-thmag_hcurl-nonlinear-Axi-sim.cfg")
+    flow = _cfg(feelpp_test_data, "HLTEST", "HLtest-flow_params.json")
+
+    mdata = {
+        "test": {
+            "value": 31000,
+            "type": "helix",
+            "filter": "",
+            "flow": flow,
+        }
+    }
+    parser = options("integration-test", "")
+    args = parser.parse_args(
+        [
+            cfg,
+            "--mdata", json.dumps(mdata),
+            "--cooling", "mean",
+            "--eps", "1e-3",
+            "--no-update-cooling",
+        ]
+    )
+
+    table, dict_df, _ = oneconfig(cfg, None, args, wd=str(tmp_path))
+
+    assert table is not None
+    assert dict_df is not None
+
+
+# ---------------------------------------------------------------------------
+# M9Bitters — bitter magnet (mirrors examples/M9Bitters.sh, single step only)
+# ---------------------------------------------------------------------------
+
+
+def test_m9bitters_bitter_oneconfig(feelpp_test_data, tmp_path):
+    """
+    Minimal integration test for a bitter-type magnet (single current step).
+
+    This mirrors the M9Bitters.sh example but runs only one configuration
+    rather than a full commissioning ramp.
+    """
+    cfg = _cfg(
+        feelpp_test_data,
+        "M9Bitters_18MW",
+        "gradHZ",
+        "M9Bitters_18MW-cfpdes-thmag_hcurl-nonlinear-Axi-sim.cfg",
+    )
+    flow = _cfg(feelpp_test_data, "M9Bitters_18MW", "M9Bitters_18MW-flow_params.json")
+
+    mdata = {
+        "HLtest": {
+            "value": 12000,
+            "type": "bitter",
+            "filter": "",
+            "relax": 0,
+            "flow": flow,
+        }
+    }
+    parser = options("integration-test", "")
+    args = parser.parse_args(
+        [
+            cfg,
+            "--mdata", json.dumps(mdata),
+            "--cooling", "gradHZ",
+            "--eps", "1e-3",
+        ]
+    )
+
+    table, dict_df, _ = oneconfig(cfg, None, args, wd=str(tmp_path))
+
+    assert table is not None
+    assert dict_df is not None

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,0 +1,168 @@
+"""
+Tests for python_magnetworkflows.params
+
+All tests in this file are pure Python — no feelpp dependency.
+"""
+
+import pytest
+import pandas as pd
+
+from python_magnetworkflows.params import CFGDIR_PLACEHOLDER, getTarget, getparam, resolve_cfgdir_path
+
+
+# ---------------------------------------------------------------------------
+# resolve_cfgdir_path
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_cfgdir_path_replaces_placeholder():
+    result = resolve_cfgdir_path("$cfgdir/data/file.csv", "/abs/path")
+    assert result == "/abs/path/data/file.csv"
+
+
+def test_resolve_cfgdir_path_no_placeholder():
+    result = resolve_cfgdir_path("/already/absolute.csv", "/basedir")
+    assert result == "/already/absolute.csv"
+
+
+def test_resolve_cfgdir_path_multiple_occurrences():
+    # str.replace replaces ALL occurrences
+    result = resolve_cfgdir_path("$cfgdir/$cfgdir/file", "/base")
+    assert result == "/base//base/file"
+
+
+def test_resolve_cfgdir_path_empty_path():
+    result = resolve_cfgdir_path("", "/base")
+    assert result == ""
+
+
+def test_resolve_cfgdir_path_empty_basedir():
+    result = resolve_cfgdir_path("$cfgdir/file.csv", "")
+    assert result == "/file.csv"
+
+
+def test_resolve_cfgdir_placeholder_constant():
+    assert CFGDIR_PLACEHOLDER == "$cfgdir"
+
+
+# ---------------------------------------------------------------------------
+# getparam
+# ---------------------------------------------------------------------------
+
+
+def test_getparam_returns_matching_keys():
+    params = {"U_H1": 1.0, "U_H2": 2.0, "N_H1": 5}
+    result = getparam("U", params, r"U_H\d+")
+    assert sorted(result) == ["U_H1", "U_H2"]
+
+
+def test_getparam_no_match_returns_empty():
+    params = {"N_H1": 5, "N_H2": 10}
+    result = getparam("U", params, r"U_H\d+")
+    assert result == []
+
+
+def test_getparam_fullmatch_only():
+    # fullmatch: "U_H1_extra" must NOT match r"U_H\d+"
+    params = {"U_H1": 1.0, "U_H1_extra": 2.0}
+    result = getparam("U", params, r"U_H\d+")
+    assert result == ["U_H1"]
+    assert "U_H1_extra" not in result
+
+
+def test_getparam_empty_parameters():
+    result = getparam("U", {}, r"U_H\d+")
+    assert result == []
+
+
+def test_getparam_returns_list():
+    params = {"hw_Channel0": 1234.0}
+    result = getparam("hw", params, r"hw_Channel\d+")
+    assert isinstance(result, list)
+    assert "hw_Channel0" in result
+
+
+def test_getparam_complex_pattern():
+    params = {
+        "Tw_Channel0": 300.0,
+        "Tw_Channel1": 301.0,
+        "dTw_Channel0": 5.0,
+        "Other": 99.0,
+    }
+    result = getparam("Tw", params, r"Tw_Channel\d+")
+    assert len(result) == 2
+    assert "dTw_Channel0" not in result
+
+
+# ---------------------------------------------------------------------------
+# getTarget
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def power_csv():
+    return pd.DataFrame(
+        {
+            "Statistics_PowerM_integrate": [100.0, 110.0],
+            "Statistics_Power_H1_integrate": [40.0, 45.0],
+            "Statistics_Power_H2_integrate": [60.0, 65.0],
+            "Unrelated_Col": [1.0, 2.0],
+        }
+    )
+
+
+@pytest.fixture()
+def power_m_targetdefs():
+    return {
+        "PowerM": {
+            "csv": "heat.measures/values.csv",
+            "rematch": r"Statistics_PowerM_\w+",
+            "post": {"type": "Statistics_PowerM", "math": "integrate"},
+        }
+    }
+
+
+def test_getTarget_filters_columns(power_csv, power_m_targetdefs):
+    df = getTarget(power_m_targetdefs, "PowerM", power_csv)
+    assert all("Statistics_PowerM" in col or col == list(df.columns)[0] for col in power_csv.columns if col in df.columns)
+    assert "Unrelated_Col" not in df.columns
+    assert "Statistics_Power_H1_integrate" not in df.columns
+
+
+def test_getTarget_renames_columns(power_csv, power_m_targetdefs):
+    df = getTarget(power_m_targetdefs, "PowerM", power_csv)
+    for col in df.columns:
+        assert "Statistics_PowerM_" not in col
+        assert "_integrate" not in col
+
+
+def test_getTarget_preserves_row_count(power_csv, power_m_targetdefs):
+    df = getTarget(power_m_targetdefs, "PowerM", power_csv)
+    assert len(df) == len(power_csv)
+
+
+def test_getTarget_missing_key_raises():
+    with pytest.raises(KeyError):
+        getTarget({}, "NonExistent", pd.DataFrame({"col": [1]}))
+
+
+def test_getTarget_no_matching_columns_returns_empty_df():
+    targetdefs = {
+        "X": {
+            "csv": "x.csv",
+            "rematch": r"NoSuchPattern_\d+",
+            "post": {"type": "NoSuchPattern", "math": "val"},
+        }
+    }
+    csv = pd.DataFrame({"Statistics_PowerM_integrate": [1.0]})
+    df = getTarget(targetdefs, "X", csv)
+    assert df.empty
+
+
+def test_getTarget_returns_deep_copy(power_csv, power_m_targetdefs):
+    """Mutating the returned DataFrame must not affect the original."""
+    original_val = power_csv["Statistics_PowerM_integrate"].iloc[0]
+    df = getTarget(power_m_targetdefs, "PowerM", power_csv)
+    col = df.columns[0]
+    df[col] = 0.0
+    assert power_csv["Statistics_PowerM_integrate"].iloc[0] == original_val

--- a/tests/test_real_methods.py
+++ b/tests/test_real_methods.py
@@ -1,0 +1,114 @@
+"""
+Tests for python_magnetworkflows.real_methods
+
+All tests in this file are pure Python — no feelpp dependency.
+
+Note on getMin: the current implementation reads the column
+``Statistics_Max{field}_{marker}_min`` (using "Max" prefix, not "Min").
+This is documented in tests so that a future fix to this naming
+inconsistency is easy to identify.
+"""
+
+import pytest
+import pandas as pd
+
+from python_magnetworkflows.real_methods import getMax, getMean, getMin
+
+
+@pytest.fixture()
+def temp_df():
+    """DataFrame simulating feelpp temperature statistics output."""
+    return pd.DataFrame(
+        {
+            "Statistics_MeanT_ConductorH1_mean": [295.0, 296.5, 300.0],
+            "Statistics_MaxT_ConductorH1_max": [310.0, 315.0, 320.0],
+            # NOTE: getMin reads Statistics_Max* (not Statistics_Min*) columns
+            "Statistics_MaxT_ConductorH1_min": [290.0, 291.0, 292.0],
+            "Statistics_MeanT_ConductorH2_mean": [298.0, 299.0, 301.0],
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# getMean
+# ---------------------------------------------------------------------------
+
+
+def test_getMean_returns_last_row_value(temp_df):
+    assert getMean(temp_df, "ConductorH1", "T") == pytest.approx(300.0)
+
+
+def test_getMean_correct_marker(temp_df):
+    assert getMean(temp_df, "ConductorH2", "T") == pytest.approx(301.0)
+
+
+def test_getMean_single_row():
+    df = pd.DataFrame({"Statistics_MeanT_M1_mean": [42.5]})
+    assert getMean(df, "M1", "T") == pytest.approx(42.5)
+
+
+def test_getMean_missing_column_raises(temp_df):
+    with pytest.raises(KeyError):
+        getMean(temp_df, "NonExistent", "T")
+
+
+# ---------------------------------------------------------------------------
+# getMax
+# ---------------------------------------------------------------------------
+
+
+def test_getMax_returns_last_row_value(temp_df):
+    assert getMax(temp_df, "ConductorH1", "T") == pytest.approx(320.0)
+
+
+def test_getMax_single_row():
+    df = pd.DataFrame({"Statistics_MaxT_M1_max": [99.9]})
+    assert getMax(df, "M1", "T") == pytest.approx(99.9)
+
+
+def test_getMax_missing_column_raises(temp_df):
+    with pytest.raises(KeyError):
+        getMax(temp_df, "NonExistent", "T")
+
+
+# ---------------------------------------------------------------------------
+# getMin — NOTE: reads Statistics_Max{field}_{marker}_min (not Statistics_Min*)
+# ---------------------------------------------------------------------------
+
+
+def test_getMin_uses_max_prefix_in_column_name():
+    """getMin reads Statistics_Max{field}_{marker}_min, not Statistics_Min{field}."""
+    df = pd.DataFrame({"Statistics_MaxT_ConductorH1_min": [288.0, 289.0, 287.5]})
+    assert getMin(df, "ConductorH1", "T") == pytest.approx(287.5)
+
+
+def test_getMin_returns_last_row_value(temp_df):
+    assert getMin(temp_df, "ConductorH1", "T") == pytest.approx(292.0)
+
+
+def test_getMin_single_row():
+    df = pd.DataFrame({"Statistics_MaxT_M1_min": [10.5]})
+    assert getMin(df, "M1", "T") == pytest.approx(10.5)
+
+
+def test_getMin_missing_column_raises(temp_df):
+    with pytest.raises(KeyError):
+        getMin(temp_df, "NonExistent", "T")
+
+
+# ---------------------------------------------------------------------------
+# All methods use iloc[-1] (last row)
+# ---------------------------------------------------------------------------
+
+
+def test_all_methods_use_last_row():
+    df = pd.DataFrame(
+        {
+            "Statistics_MeanT_M1_mean": [1.0, 2.0, 99.0],
+            "Statistics_MaxT_M1_max": [5.0, 6.0, 88.0],
+            "Statistics_MaxT_M1_min": [0.5, 0.6, 77.0],
+        }
+    )
+    assert getMean(df, "M1", "T") == pytest.approx(99.0)
+    assert getMax(df, "M1", "T") == pytest.approx(88.0)
+    assert getMin(df, "M1", "T") == pytest.approx(77.0)

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,0 +1,67 @@
+"""
+Tests for python_magnetworkflows.solver
+
+This entire module is skipped at collection time if feelpp.core is not
+importable (system Debian package required). The pytestmark applies the
+``feelpp`` marker to every test function for -m filtering.
+"""
+
+import json
+
+import pytest
+
+pytest.importorskip("feelpp.core")
+
+pytestmark = pytest.mark.feelpp
+
+from python_magnetworkflows import solver  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Smoke test — verify the module has the expected public API
+# ---------------------------------------------------------------------------
+
+
+def test_solver_module_has_public_api():
+    """Confirm solver module imports and exposes its public API."""
+    assert callable(solver.init)
+    assert callable(solver.solve)
+    assert callable(solver.create_field)
+    assert callable(solver.init_field)
+    assert callable(solver.update)
+
+
+# ---------------------------------------------------------------------------
+# solver.update — pure file I/O, no live feelpp objects needed
+# ---------------------------------------------------------------------------
+
+
+def test_update_replaces_parameters(tmp_path):
+    """update() reads a JSON file, replaces the Parameters section, and writes it back."""
+    model = {"Parameters": {"U_H1": 1.0, "U_H2": 2.0}, "Models": {"heat": {}}}
+    jsonfile = tmp_path / "model.json"
+    jsonfile.write_text(json.dumps(model))
+
+    new_params = {"U_H1": 5.0, "U_H2": 7.5}
+    solver.update(str(jsonfile), new_params, debug=False)
+
+    written = json.loads(jsonfile.read_text())
+    assert written["Parameters"] == new_params
+
+
+def test_update_preserves_non_parameter_keys(tmp_path):
+    """Non-Parameters sections in the JSON are not overwritten."""
+    model = {
+        "Parameters": {"U_H1": 1.0},
+        "Models": {"heat": {}},
+        "Meshes": {"cfpdes": {}},
+    }
+    jsonfile = tmp_path / "model.json"
+    jsonfile.write_text(json.dumps(model))
+
+    solver.update(str(jsonfile), {"U_H1": 99.0}, debug=False)
+
+    written = json.loads(jsonfile.read_text())
+    assert "Models" in written
+    assert "Meshes" in written
+    assert written["Models"] == {"heat": {}}


### PR DESCRIPTION
- Add tests/ directory with 54 pure-Python unit tests covering params.py, args.py, and real_methods.py (always run, no feelpp required)
- Add test_solver.py and test_integration.py gated behind pytest.importorskip("feelpp.core") so they are skipped at collection time when feelpp is not installed
- Register feelpp and slow pytest markers in pyproject.toml and conftest.py to avoid PytestUnknownMarkWarning under filterwarnings = ["error"]
- Add feelpp_test_data session fixture driven by MAGNETWORKFLOWS_TEST_DATA env var for integration tests that run actual simulations
- Add docs/testing.md with setup instructions, marker usage, and CI guidance

https://claude.ai/code/session_01M1aVoVFkb9otPWk88Deu1T